### PR TITLE
refactored transactions

### DIFF
--- a/src/main/java/com/github/cargoclean/core/port/persistence/PersistenceGatewayOutputPort.java
+++ b/src/main/java/com/github/cargoclean/core/port/persistence/PersistenceGatewayOutputPort.java
@@ -18,6 +18,18 @@ import java.util.stream.Collectors;
 
 public interface PersistenceGatewayOutputPort {
 
+    /**
+     * Executes provided {@linkplain Runnable} in a transaction configured
+     * with default propagation strategy and isolation level.
+     *
+     * @param runnable runnable to execute
+     * @throws PersistenceOperationError if there was a problem setting up or executing
+     *                                   a transaction, all other {@linkplain RuntimeException}s
+     *                                   which may be thrown by the {@code runnable} itself are
+     *                                   propagated to the caller
+     */
+    void doInTransaction(Runnable runnable);
+
     TrackingId nextTrackingId();
 
     EventId nextEventId();
@@ -65,8 +77,6 @@ public interface PersistenceGatewayOutputPort {
     void recordHandlingEvent(HandlingEvent event);
 
     HandlingHistory handlingHistory(TrackingId cargoId);
-
-    void rollback();
 
     default Map<UnLocode, Region> allRegionsMap() {
         return allLocations().stream()

--- a/src/main/java/com/github/cargoclean/core/usecase/editlocation/EditLocationsUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/editlocation/EditLocationsUseCase.java
@@ -8,8 +8,6 @@ import com.github.cargoclean.core.port.persistence.PersistenceGatewayOutputPort;
 import com.github.cargoclean.core.port.security.SecurityOutputPort;
 import lombok.RequiredArgsConstructor;
 
-import javax.transaction.Transactional;
-
 @RequiredArgsConstructor
 public class EditLocationsUseCase implements EditLocationsInputPort {
 
@@ -23,22 +21,22 @@ public class EditLocationsUseCase implements EditLocationsInputPort {
     public void prepareAddNewLocationView() {
 
         try {
+
             // only manager can add locations
             securityOps.assertThatUserIsManager();
+
+            presenter.presentAddNewLocationForm();
+
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
-
-        presenter.presentAddNewLocationForm();
 
     }
 
     @Override
-    @Transactional
     public void registerNewLocation(String unLocodeText, String locationName, String regionName) {
-        Location savedLocation;
         try {
+            Location savedLocation;
             // only manager can add locations
             securityOps.assertThatUserIsManager();
 
@@ -60,12 +58,10 @@ public class EditLocationsUseCase implements EditLocationsInputPort {
             // save new Location
             savedLocation = gatewayOps.saveLocation(location);
 
+            presenter.presentResultOfSuccessfulRegistrationOfNewLocation(savedLocation);
         } catch (Exception e) {
-            gatewayOps.rollback();
             presenter.presentError(e);
-            return;
         }
 
-        presenter.presentResultOfSuccessfulRegistrationOfNewLocation(savedLocation);
     }
 }

--- a/src/main/java/com/github/cargoclean/core/usecase/report/ReportUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/report/ReportUseCase.java
@@ -16,19 +16,16 @@ public class ReportUseCase implements ReportInputPort {
     @Override
     public void reportExpectedArrivals() {
 
-        final List<ExpectedArrivals> expectedArrivals;
-
         try {
+            final List<ExpectedArrivals> expectedArrivals;
 
             // just query the gateway
             expectedArrivals = gatewayOps.queryForExpectedArrivals();
 
+            presenter.presentExpectedArrivals(expectedArrivals);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
-
-        presenter.presentExpectedArrivals(expectedArrivals);
 
     }
 }

--- a/src/main/java/com/github/cargoclean/core/usecase/routing/RoutingUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/routing/RoutingUseCase.java
@@ -26,25 +26,23 @@ public class RoutingUseCase implements RoutingInputPort {
 
     @Override
     public void showCargo(String cargoTrackingId) {
-        final Cargo cargo;
         try {
+            final Cargo cargo;
             securityOps.assertThatUserIsAgent();
             cargo = gatewayOps.obtainCargoByTrackingId(TrackingId.of(cargoTrackingId));
+            presenter.presentCargoDetails(cargo);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
-
-        presenter.presentCargoDetails(cargo);
 
     }
 
     @Override
     public void selectItinerary(String cargoTrackingId) {
-        Cargo cargo;
-        List<Itinerary> itineraries;
-        TrackingId trackingId;
         try {
+            Cargo cargo;
+            List<Itinerary> itineraries;
+            TrackingId trackingId;
 
             securityOps.assertThatUserIsAgent();
 
@@ -63,12 +61,11 @@ public class RoutingUseCase implements RoutingInputPort {
             // get candidate itineraries from external service
             itineraries = routingServiceOps.fetchRoutesForSpecification(trackingId, routeSpecification);
 
+            presenter.presentCandidateRoutes(cargo, itineraries);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
 
-        presenter.presentCandidateRoutes(cargo, itineraries);
     }
 
     @Transactional
@@ -115,13 +112,10 @@ public class RoutingUseCase implements RoutingInputPort {
             // persist updated cargo
             gatewayOps.saveCargo(updatedCargo);
 
+            presenter.presentResultOfAssigningRouteToCargo(trackingId);
         } catch (Exception e) {
-            gatewayOps.rollback();
             presenter.presentError(e);
-            return;
         }
-
-        presenter.presentResultOfAssigningRouteToCargo(trackingId);
 
     }
 }

--- a/src/main/java/com/github/cargoclean/core/usecase/tracking/TrackingUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/tracking/TrackingUseCase.java
@@ -20,7 +20,6 @@ public class TrackingUseCase implements TrackingInputPort {
 
     private final PersistenceGatewayOutputPort gatewayOps;
 
-
     @Override
     public void initializeCargoTrackingView() {
         try {
@@ -34,11 +33,11 @@ public class TrackingUseCase implements TrackingInputPort {
 
     @Override
     public void trackCargo(String cargoTrackingId) {
-        TrackingId trackingId;
-        Cargo cargo;
-        HandlingHistory handlingHistory;
-        Map<UnLocode, Location> allLocationsMap;
         try {
+            TrackingId trackingId;
+            Cargo cargo;
+            HandlingHistory handlingHistory;
+            Map<UnLocode, Location> allLocationsMap;
             securityOps.assertThatUserIsAgent();
 
             trackingId = TrackingId.of(cargoTrackingId);
@@ -64,11 +63,10 @@ public class TrackingUseCase implements TrackingInputPort {
             // load all locations and make a map of UnLocode to Locations
             allLocationsMap = gatewayOps.allLocationsMap();
 
+            presenter.presentCargoTrackingInformation(cargo, handlingHistory, allLocationsMap);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
 
-        presenter.presentCargoTrackingInformation(cargo, handlingHistory, allLocationsMap);
     }
 }

--- a/src/main/java/com/github/cargoclean/core/usecase/welcome/WelcomeUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/welcome/WelcomeUseCase.java
@@ -18,19 +18,18 @@ public class WelcomeUseCase implements WelcomeInputPort {
 
     @Override
     public void welcome() {
-        final String username;
-        final List<CargoInfo> cargoes;
         try {
+            final String username;
+            final List<CargoInfo> cargoes;
 
             username = securityOps.username().orElse(null);
 
             cargoes = gatewayOps.allCargoes();
 
+            presenter.presentHomePage(username, cargoes);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
 
-        presenter.presentHomePage(username, cargoes);
     }
 }

--- a/src/main/resources/templates/add-location.html
+++ b/src/main/resources/templates/add-location.html
@@ -38,7 +38,7 @@
             </div>
 
             <div class="row mb-3">
-                <label for="region" class="col-2 col-form-label">Location</label>
+                <label for="region" class="col-2 col-form-label">Region</label>
                 <div class="col-1">
                     <input id="region" type="text" class="form-label"
                            th:placeholder="*{hintRegion}"


### PR DESCRIPTION
Remove @Transactional on the use cases, handle transactions on the individual methods of the gateway. Provide for a possibility to manually run a block of code in a use case as transactional, if needed (using org.springframework.transaction.support.TransactionTemplate in the persistence gateway).