### PR TITLE
refactor(transaction): remove broken methods, decouple cache, fix Han…

### DIFF
--- a/src/main/java/com/github/cargoclean/core/port/transaction/TransactionOperationsOutputPort.java
+++ b/src/main/java/com/github/cargoclean/core/port/transaction/TransactionOperationsOutputPort.java
@@ -63,37 +63,11 @@ public interface TransactionOperationsOutputPort {
     void doAfterCommit(TransactionRunnableWithoutResult runnableWithoutResult);
 
     /**
-     * Executes the provided runnable, returning the result of the execution, if called outside
-     * any transactional context. Otherwise, executes the runnable only after a successful
-     * commit of the current transaction.
-     *
-     * @param runnableWithResult a runnable with some return object
-     * @param <R>                any type
-     * @return object returned by the runnable
-     */
-    <R> R doAfterCommitWithResult(TransactionRunnableWithResult<R> runnableWithResult);
-
-    /**
-     * Executes the provided runnable if called outside any transactional context.
-     * Otherwise, executes the runnable only after the current transaction was rolled back.
+     * Executes the provided runnable only after the current transaction was rolled back.
+     * If called outside any transactional context, this method is a no-op: the runnable
+     * is not executed since there is no transaction to roll back.
      *
      * @param runnableWithoutResult a runnable which does not return anything
      */
     void doAfterRollback(TransactionRunnableWithoutResult runnableWithoutResult);
-
-    /**
-     * Executes the provided runnable, returning the result of the execution, if called outside
-     * any transactional context. Otherwise, executes the runnable only after the current
-     * transaction was rolled back.
-     *
-     * @param runnableWithResult a runnable with some return object
-     * @param <R>                any type
-     * @return object returned by the runnable
-     */
-    <R> R doAfterRollbackWithResult(TransactionRunnableWithResult<R> runnableWithResult);
-
-    /**
-     * Rolls back currently active transaction.
-     */
-    void rollback();
 }

--- a/src/main/java/com/github/cargoclean/core/usecase/handling/HandlingUseCase.java
+++ b/src/main/java/com/github/cargoclean/core/usecase/handling/HandlingUseCase.java
@@ -41,62 +41,55 @@ public class HandlingUseCase implements HandlingInputPort {
 
         try {
 
+            // make sure user is a manager
+            securityOps.assertThatUserIsManager();
+
+            EventId eventId = gatewayOps.nextEventId();
+
+            // parse identifiers and create value objects: outside the transaction
+            // since validation does not require a consistency boundary
+            VoyageNumber voyageNumber;
+            UnLocode location;
+            TrackingId cargoId;
+            UtcDateTime completionDateTime;
+            try {
+                voyageNumber = Optional.ofNullable(voyageNumberStr)
+                        .map(VoyageNumber::of).orElse(null);
+                location = UnLocode.of(locationStr);
+                cargoId = TrackingId.of(cargoIdStr);
+                completionDateTime = UtcDateTime.of(completionTime);
+            } catch (InvalidDomainObjectError e) {
+                presenter.presentInvalidParametersError(e);
+                return;
+            }
+
+            // construct new handling event
+            HandlingEvent handlingEvent = HandlingEvent.builder()
+                    .eventId(eventId)
+                    .voyageNumber(voyageNumber)
+                    .location(location)
+                    .cargoId(cargoId)
+                    .completionTime(completionDateTime)
+                    .registrationTime(UtcDateTime.now())
+                    .type(type)
+                    .build();
+
+            /*
+                Point of interest:
+                -----------------
+                Only persistence and event dispatch are wrapped in a transaction:
+                a "poor man's outbox" pattern ensuring that the handling event
+                is recorded and the domain event is dispatched atomically.
+                Event handling is performed synchronously in the same thread
+                via "TransactionalEventListener" which guarantees that events
+                are processed only after this transaction commits.
+             */
+
             txOps.doInTransaction(() -> {
-
-                // make sure user is a manager
-                securityOps.assertThatUserIsManager();
-
-                EventId eventId = gatewayOps.nextEventId();
-
-                // parse identifiers and create value objects
-                TrackingId cargoId;
-                VoyageNumber voyageNumber;
-                UnLocode location;
-                UtcDateTime completionDateTime;
-                try {
-                    voyageNumber = Optional.ofNullable(voyageNumberStr)
-                            .map(VoyageNumber::of).orElse(null);
-                    location = UnLocode.of(locationStr);
-                    cargoId = TrackingId.of(cargoIdStr);
-                    completionDateTime = UtcDateTime.of(completionTime);
-                } catch (InvalidDomainObjectError e) {
-                    txOps.doAfterRollback(() -> presenter.presentInvalidParametersError(e));
-                    return;
-                }
-
-                // construct new handling event
-                HandlingEvent handlingEvent = HandlingEvent.builder()
-                        .eventId(eventId)
-                        .voyageNumber(voyageNumber)
-                        .location(location)
-                        .cargoId(cargoId)
-                        .completionTime(completionDateTime)
-                        .registrationTime(UtcDateTime.now())
-                        .type(type)
-                        .build();
-
-                // record handling event
                 gatewayOps.recordHandlingEvent(handlingEvent);
-
-                /*
-                    Point of interest:
-                    -----------------
-                    We a dispatching "HandlingEvent" as a domain event to be
-                    processed by the primary adapter which will execute
-                    (another) use case for updating delivery progress for
-                    the cargo. Note that, in the current implementation,
-                    event dispatch and event handling are performed synchronously
-                    in the same thread. We also use "TransactionalEventListener"
-                    as an adapter listening to the events. This will guarantee that
-                    events are processed only after this transaction commits.
-                 */
-
-                // dispatch a domain event signaling that a new handling event was recorded for the cargo
                 eventsOps.dispatch(handlingEvent);
-
                 txOps.doAfterCommit(() -> presenter.presentResultOfRegisteringHandlingEvent(cargoId, handlingEvent));
             });
-
 
         } catch (Exception e) {
             presenter.presentError(e);

--- a/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/CacheInvalidationOnRollback.java
+++ b/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/CacheInvalidationOnRollback.java
@@ -1,0 +1,16 @@
+package com.github.cargoclean.infrastructure.adapter.cache;
+
+/**
+ * Callback to register cache invalidation when a transaction rolls back.
+ * Designed to be called from within an active transaction context.
+ * When called outside a transaction, implementations should be a no-op.
+ */
+@FunctionalInterface
+public interface CacheInvalidationOnRollback {
+
+    /**
+     * Registers a synchronization callback that will clear all caches
+     * if the current transaction is rolled back.
+     */
+    void register();
+}

--- a/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/CacheUtils.java
+++ b/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/CacheUtils.java
@@ -1,4 +1,4 @@
-package com.github.cargoclean.infrastructure.adapter;
+package com.github.cargoclean.infrastructure.adapter.cache;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 /**
  * Helper class with static methods to work with {@linkplain CacheManager}.
- * May be shared by several adapters.
  */
 public class CacheUtils {
 

--- a/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/SpringCacheInvalidationOnRollback.java
+++ b/src/main/java/com/github/cargoclean/infrastructure/adapter/cache/SpringCacheInvalidationOnRollback.java
@@ -1,0 +1,44 @@
+package com.github.cargoclean.infrastructure.adapter.cache;
+
+import com.github.cargoclean.infrastructure.adapter.cache.CacheUtils;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Registers a transaction synchronization callback which will
+ * clear all caches after a rollback of a transaction.
+ * This keeps cache invalidation concerns within the caching layer
+ * rather than coupling them to the transaction adapter.
+ *
+ * @see CacheUtils#clearAllCaches(CacheManager)
+ */
+@Component
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
+@Slf4j
+public class SpringCacheInvalidationOnRollback implements CacheInvalidationOnRollback {
+
+    CacheManager cacheManager;
+
+    @Override
+    public void register() {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
+                    log.debug("[Cache] Clearing all caches on rollback");
+                    CacheUtils.clearAllCaches(cacheManager);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/github/cargoclean/infrastructure/adapter/transaction/SpringTransactionAdapter.java
+++ b/src/main/java/com/github/cargoclean/infrastructure/adapter/transaction/SpringTransactionAdapter.java
@@ -3,21 +3,16 @@ package com.github.cargoclean.infrastructure.adapter.transaction;
 import com.github.cargoclean.core.port.transaction.TransactionOperationsOutputPort;
 import com.github.cargoclean.core.port.transaction.TransactionRunnableWithResult;
 import com.github.cargoclean.core.port.transaction.TransactionRunnableWithoutResult;
-import com.github.cargoclean.infrastructure.adapter.CacheUtils;
+import com.github.cargoclean.infrastructure.adapter.cache.CacheInvalidationOnRollback;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.NoTransactionException;
-import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 /*
     References:
@@ -30,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * transaction SPI.
  *
  * @see TransactionTemplate
- * @see TransactionInterceptor
  * @see TransactionSynchronizationManager
  */
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
@@ -40,7 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class SpringTransactionAdapter implements TransactionOperationsOutputPort {
 
     TransactionTemplate transactionTemplate;
-    CacheManager cacheManager;
+    CacheInvalidationOnRollback cacheInvalidationOnRollback;
 
     @Qualifier("read-only")
     TransactionTemplate readOnlyTransactionTemplate;
@@ -52,13 +46,7 @@ public class SpringTransactionAdapter implements TransactionOperationsOutputPort
             readOnlyTransactionTemplate.executeWithoutResult(transactionStatus -> runnableWithoutResult.run());
         } else {
             transactionTemplate.executeWithoutResult(transactionStatus -> {
-                /*
-                    Point of interest:
-                    -----------------
-                    We need to register a callback which will clear
-                    caches in case of a rollback of the current transaction.
-                 */
-                registerCacheInvalidationOnRollback();
+                cacheInvalidationOnRollback.register();
                 runnableWithoutResult.run();
             });
         }
@@ -71,7 +59,7 @@ public class SpringTransactionAdapter implements TransactionOperationsOutputPort
             return readOnlyTransactionTemplate.execute(transactionStatus -> runnableWithResult.run());
         } else {
             return transactionTemplate.execute(transactionStatus -> {
-                registerCacheInvalidationOnRollback();
+                cacheInvalidationOnRollback.register();
                 return runnableWithResult.run();
             });
         }
@@ -98,34 +86,10 @@ public class SpringTransactionAdapter implements TransactionOperationsOutputPort
     }
 
     @Override
-    public <R> R doAfterCommitWithResult(TransactionRunnableWithResult<R> runnableWithResult) {
-        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            // not in transaction, just execute the runnable
-            log.debug("[Transaction] Not in transaction, executing runnable (with a result) from \"doAfterCommitWithResult\" directly");
-            return runnableWithResult.run();
-        }
-
-        final AtomicReference<R> result = new AtomicReference<>();
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-
-            @Override
-            public void afterCompletion(int status) {
-                if (status == TransactionSynchronization.STATUS_COMMITTED) {
-                    log.debug("[Transaction][After commit] Executing runnable (with a result) after commit");
-                    result.set(runnableWithResult.run());
-                }
-            }
-
-        });
-        return result.get();
-    }
-
-    @Override
     public void doAfterRollback(TransactionRunnableWithoutResult runnableWithoutResult) {
         if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            // not in transaction, just execute the runnable
-            log.debug("[Transaction] Not in transaction, executing runnable (without a result) from \"doAfterRollback\" directly");
-            runnableWithoutResult.run();
+            // no active transaction means no rollback to react to: no-op
+            log.debug("[Transaction] No active transaction, ignoring doAfterRollback callback");
             return;
         }
 
@@ -135,56 +99,6 @@ public class SpringTransactionAdapter implements TransactionOperationsOutputPort
                 if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
                     log.debug("[Transaction][After rollback] Executing runnable (without a result) after rollback");
                     runnableWithoutResult.run();
-                }
-            }
-        });
-    }
-
-    @Override
-    public <R> R doAfterRollbackWithResult(TransactionRunnableWithResult<R> runnableWithResult) {
-        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            // not in transaction, just execute the runnable
-            log.debug("[Transaction] Not in transaction, executing runnable (with a result) from \"doAfterRollbackWithResult\" directly");
-            return runnableWithResult.run();
-        }
-
-        final AtomicReference<R> result = new AtomicReference<>();
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(int status) {
-                if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
-                    log.debug("[Transaction] Executing runnable (with a result) after rollback");
-                    result.set(runnableWithResult.run());
-                }
-            }
-        });
-        return result.get();
-    }
-
-    @Override
-    public void rollback() {
-        try {
-            TransactionInterceptor.currentTransactionStatus().setRollbackOnly();
-            log.debug("[Transaction] Will roll back current transaction");
-        } catch (NoTransactionException e) {
-            // do nothing if not in transaction
-        }
-    }
-
-    /**
-     * Registers a custom transaction synchronization callback which will
-     * clear all caches after a rollback of a transaction.
-     */
-    private void registerCacheInvalidationOnRollback() {
-        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
-            return;
-        }
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(int status) {
-                if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
-                    log.debug("[Transaction] [Cache] Clearing all caches on rollback");
-                    CacheUtils.clearAllCaches(cacheManager);
                 }
             }
         });

--- a/src/test/java/com/github/cargoclean/core/usecase/AbstractUseCaseTestSupport.java
+++ b/src/test/java/com/github/cargoclean/core/usecase/AbstractUseCaseTestSupport.java
@@ -66,11 +66,6 @@ public abstract class AbstractUseCaseTestSupport {
             return null;
         }).when(txOps).doAfterCommit(any(TransactionRunnableWithoutResult.class));
 
-        lenient().doAnswer(invocation -> {
-            ((TransactionRunnableWithoutResult) invocation.getArgument(0)).run();
-            return null;
-        }).when(txOps).doAfterRollback(any(TransactionRunnableWithoutResult.class));
-
     }
 
     protected abstract ErrorHandlingPresenterOutputPort getPresenter();


### PR DESCRIPTION
…dlingUseCase

- Remove doAfterCommitWithResult, doAfterRollbackWithResult, rollback() from TransactionOperationsOutputPort (broken or unused)
- Extract cache-invalidation-on-rollback into dedicated CacheInvalidationOnRollback component in cache adapter package
- Move CacheUtils to infrastructure.adapter.cache package
- Fix HandlingUseCase: tighten transactional boundary to persistence + event dispatch only; move value object validation outside transaction with direct presenter call (fixes silent error swallowing bug)
- Make doAfterRollback a no-op when no transaction is active
- Remove doAfterRollback mock stub from AbstractUseCaseTestSupport